### PR TITLE
clickaway on popover

### DIFF
--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -1,0 +1,40 @@
+import { RefObject, useEffect } from 'react';
+
+const EVENTS = ['mousedown', 'touchstart'];
+
+export type OnClickAwayCallback = (event: Event) => void;
+
+export const useClickAway = (
+    references: Array<RefObject<HTMLElement | null>>,
+    onClickAway?: OnClickAwayCallback
+): void => {
+    useEffect(() => {
+        const handler = (event: Event): void => {
+            if (onClickAway) {
+                const isClickAway = references.every((reference) => {
+                    const { current: element } = reference;
+
+                    return element && !element.contains(event.target as Node);
+                });
+
+                if (isClickAway) {
+                    onClickAway(event);
+                }
+            }
+        };
+
+        if (onClickAway) {
+            for (const eventName of EVENTS) {
+                document.addEventListener(eventName, handler);
+            }
+        }
+
+        return (): void => {
+            if (onClickAway) {
+                for (const eventName of EVENTS) {
+                    document.removeEventListener(eventName, handler);
+                }
+            }
+        };
+    }, [onClickAway, references]);
+};

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -2,11 +2,13 @@ import { RefObject, useEffect } from 'react';
 
 const EVENTS = ['mousedown', 'touchstart'];
 
-export type OnClickAwayCallback = (event: Event) => void;
+type TonClickAwayCallback = (event: Event) => void;
+
+type TuseClickAwayReferences = Array<RefObject<HTMLElement | null>>;
 
 export const useClickAway = (
-    references: Array<RefObject<HTMLElement | null>>,
-    onClickAway?: OnClickAwayCallback
+    references: TuseClickAwayReferences,
+    onClickAway?: TonClickAwayCallback
 ): void => {
     useEffect(() => {
         const handler = (event: Event): void => {
@@ -38,3 +40,5 @@ export const useClickAway = (
         };
     }, [onClickAway, references]);
 };
+
+export type { TonClickAwayCallback, TuseClickAwayReferences };

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -3,6 +3,7 @@ import Utils from './utils';
 export * from './color-utils';
 export * from './theme-utils';
 export * from './constants';
+export * from './hooks';
 export * from './types';
 
 export { Utils };

--- a/src/utilities/popover/Popover.props.ts
+++ b/src/utilities/popover/Popover.props.ts
@@ -32,6 +32,12 @@ type PPopover = {
      */
     offset?: TPopoverOffset;
     /**
+     * handle clicking away from the popover and anchor references (refs).
+     * this is very useful for setting isVisible state, or perform other actions
+     * when clicking away.
+     */
+    onClickAway?: () => void;
+    /**
      * custom className
      */
     className?: string;

--- a/src/utilities/popover/Popover.props.ts
+++ b/src/utilities/popover/Popover.props.ts
@@ -1,5 +1,7 @@
 import { MutableRefObject, ReactNode } from 'react';
 
+import { TonClickAwayCallback } from '../../shared';
+
 import { TPopoverOffset, TPopoverPlacement } from './Popover.types';
 
 type PPopover = {
@@ -36,7 +38,7 @@ type PPopover = {
      * this is very useful for setting isVisible state, or perform other actions
      * when clicking away.
      */
-    onClickAway?: () => void;
+    onClickAway?: TonClickAwayCallback;
     /**
      * custom className
      */

--- a/src/utilities/popover/Popover.stories.mdx
+++ b/src/utilities/popover/Popover.stories.mdx
@@ -72,6 +72,7 @@ export const popoverArgs = {
                         anchorReference={buttonReference}
                         placement={placement}
                         offset={offset}
+                        onClickAway={() => setIsVisible(false)}
                     >
                         <Shape elevation={3} width={200}>
                             <Grid justify={'center'} padding={Spacing.all(100)}>

--- a/src/utilities/popover/Popover.tsx
+++ b/src/utilities/popover/Popover.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { usePopper } from 'react-popper';
 
+import { useClickAway } from '../../shared';
 import Transition from '../transition/Transition';
 
 import {
@@ -14,6 +15,7 @@ const Popover = ({
     anchorReference,
     children,
     isVisible,
+    onClickAway,
     noAnimation = false,
     placement = DEFAULT_POPOVER_PLACEMENT,
     offset = DEFAULT_POPOVER_OFFSET,
@@ -30,6 +32,10 @@ const Popover = ({
             },
         ],
     });
+
+    // when a onClickAway callback is provided it will fire when the user clicks
+    // away from the button or the popover (basically everything else)
+    useClickAway([popperReference, anchorReference], onClickAway);
 
     return (
         <div ref={popperReference} style={styles.popper} {...attributes.popper}>


### PR DESCRIPTION
This PR adds several small changes:

1. adding a new file `shared/hooks.ts` and exporting all member exports in `shared/index.ts`
2. adds `useClickAway` hook to the `hooks.ts` file to have an easy and performant way of using click-away callbacks
3. implements that hook in the `Popover` component

example usage:

```typescript jsx
    const popperReference = useRef(null);
    const { styles, attributes } = usePopper(anchorReference.current, popperReference.current, {
        placement,
    });

    useClickAway([popperReference, anchorReference], onClickAway);

    return (
        <div ref={popperReference} style={styles.popper} {...attributes.popper}>
            <Transition
                isVisible={isVisible}
                type={['fade', 'scale']}
                speed={noAnimation ? 'instant' : 'normal'}
            >
                {children}
            </Transition>
        </div>
    );
```

the type for useClickAway is

```typescript
(
    references: Array<RefObject<HTMLElement | null>>,
    onClickAway?: OnClickAwayCallback
) =>  void
```
