### PR TITLE
padding + margin added to layout components

### DIFF
--- a/src/foundations/shape/Shape.props.ts
+++ b/src/foundations/shape/Shape.props.ts
@@ -1,10 +1,9 @@
-import { ReactNode, ReactNodeArray } from 'react';
-
+import { PGlobals } from '../../shared/props';
 import { TElevationLevel } from '../../utilities/elevation';
 
 import { TShapeBorderRadius, TShapeElement } from './Shape.types';
 
-type PShape = {
+type PShape = PGlobals & {
     /**
      * The border-radius size
      * @default 0
@@ -49,14 +48,6 @@ type PShape = {
      * @default theme.background.shape
      */
     backgroundColor?: string;
-    /**
-     * custom className
-     */
-    className?: string;
-    /**
-     * component children
-     */
-    children?: ReactNode | ReactNodeArray;
 };
 
 type PShapeRoot = Omit<PShape, 'className'>;

--- a/src/foundations/shape/Shape.root.tsx
+++ b/src/foundations/shape/Shape.root.tsx
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 import { FlattenSimpleInterpolation, ThemedStyledProps } from 'styled-components/ts3.6';
 
 import applyElevation from '../../utilities/elevation';
+import { applyMargin, applyPadding } from '../../utilities/spacing';
 import { TTheme } from '../../utilities/theme';
 import { Utils } from '../../shared';
 
@@ -20,6 +21,8 @@ const ShapeRoot = styled.div.withConfig<PShapeRoot>({
         width,
         height,
         theme,
+        padding,
+        margin,
         backgroundColor = theme.background.shape,
     }: ThemedStyledProps<PShapeRoot, TTheme>): FlattenSimpleInterpolation => css`
         display: flex;
@@ -27,6 +30,9 @@ const ShapeRoot = styled.div.withConfig<PShapeRoot>({
 
         ${applyShape({ width, height, radius })};
         ${applyElevation({ elevation, elevationOnHover }, theme.type === 'dark')};
+
+        ${padding && applyPadding(padding)};
+        ${margin && applyMargin(margin)};
     `
 );
 

--- a/src/shared/props.ts
+++ b/src/shared/props.ts
@@ -1,3 +1,7 @@
+import { ReactNode, ReactNodeArray } from 'react';
+
+import { TSpacingDefinition } from '../utilities/spacing';
+
 /**
  * This section contains attributes specific to common user interface elements
  * found on GUI systems or in rich internet applications which receive user
@@ -243,7 +247,46 @@ type PAriaAllAttributes = PAriaWidgetAttributes &
     PAriaDragAndDropAttributes &
     PAriaRelationshipAttributes;
 
+/**
+ * implements padding and margin spacing properties to a components properties
+ * definition, where they are needed.
+ *
+ * Is part of the type PGlobals, but can be used separately.
+ */
+type PGlobalsLayout = {
+    /**
+     * padding according to `TSpacingDefinition` type
+     */
+    padding?: TSpacingDefinition;
+    /**
+     * margin according to `TSpacingDefinition` type
+     */
+    margin?: TSpacingDefinition;
+};
+
+/**
+ * implements className and children properties to a components properties
+ * definition, where they are needed.
+ *
+ * Is part of the type PGlobals, but can be used separately.
+ */
+type PGlobalsMisc = {
+    /**
+     * custom className
+     */
+    className?: string;
+    /**
+     * component children
+     */
+    children?: ReactNode | ReactNodeArray;
+};
+
+type PGlobals = PGlobalsMisc & PGlobalsLayout;
+
 export type {
+    PGlobals,
+    PGlobalsMisc,
+    PGlobalsLayout,
     PAriaWidgetAttributes,
     PAriaLiveRegionAttributes,
     PAriaDragAndDropAttributes,

--- a/src/utilities/grid/Grid.mixins.ts
+++ b/src/utilities/grid/Grid.mixins.ts
@@ -91,8 +91,8 @@ const applyGrid = ({
 }: PApplyGrid): FlattenSimpleInterpolation => css`
     display: grid;
 
-    grid-template-rows: ${columnsTemplate};
-    grid-template-columns: ${rowsTemplate};
+    grid-template-columns: ${columnsTemplate};
+    grid-template-rows: ${rowsTemplate};
     grid-template-areas: ${areasTemplate};
 
     column-gap: ${Utils.isNumber(gap) || Utils.isString(gap)

--- a/src/utilities/grid/Grid.props.ts
+++ b/src/utilities/grid/Grid.props.ts
@@ -1,5 +1,7 @@
-import React, { ReactNode, ReactNodeArray } from 'react';
+import React from 'react';
 import { Property } from 'csstype';
+
+import { PGlobals, PGlobalsLayout } from '../../shared/props';
 
 import {
     TGridGapProperty,
@@ -8,29 +10,23 @@ import {
     TGridPlaceItemsProperty,
 } from './Grid.types';
 
-type PGrid = PApplyGrid & {
-    /**
-     * the element the Grid should be rendered with
-     */
-    element?: string | React.FC;
-    /**
-     * component children
-     */
-    children?: ReactNode | ReactNodeArray;
-};
+type PGrid = PApplyGrid &
+    PGlobals & {
+        /**
+         * the element the Grid should be rendered with
+         */
+        element?: string | React.FC;
+    };
 
-type PGridItem = PApplyGridItem & {
-    /**
-     * the element the Grid should be rendered with
-     */
-    element?: string | React.FC;
-    /**
-     * component children
-     */
-    children?: ReactNode | ReactNodeArray;
-};
+type PGridItem = PApplyGridItem &
+    PGlobals & {
+        /**
+         * the element the Grid should be rendered with
+         */
+        element?: string | React.FC;
+    };
 
-type PApplyGrid = {
+type PApplyGrid = PGlobalsLayout & {
     /**
      * possible values align with the corresponding CSS property for
      * `grid-columns-template`
@@ -84,7 +80,7 @@ type PApplyGrid = {
     placeContent?: TGridPlaceContentProperty;
 };
 
-type PApplyGridItem = {
+type PApplyGridItem = PGlobalsLayout & {
     /**
      * possible values align with the corresponding CSS property
      * `grid-column`

--- a/src/utilities/grid/Grid.tsx
+++ b/src/utilities/grid/Grid.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Utils } from '../../shared';
+import { applyMargin, applyPadding } from '../spacing';
 
 import { applyGrid, applyGridItem } from './Grid.mixins';
 import { DEFAULT_GRID_ELEMENT, DEFAULT_GRID_ITEM_ELEMENT } from './Grid.constants';
@@ -17,7 +18,13 @@ const GridRoot = styled.div.withConfig({
             'placeItems',
             'placeContent',
         ]) && validator(property),
-})((props: PApplyGrid) => applyGrid(props));
+})(
+    ({ padding, margin, ...rest }: PApplyGrid) => css`
+        ${applyGrid(rest)};
+        ${padding && applyPadding(padding)};
+        ${margin && applyMargin(margin)};
+    `
+);
 
 const Grid = ({ element = DEFAULT_GRID_ELEMENT, ...rest }: PGrid): JSX.Element => (
     <GridRoot {...rest} as={element} />
@@ -26,7 +33,13 @@ const Grid = ({ element = DEFAULT_GRID_ELEMENT, ...rest }: PGrid): JSX.Element =
 const GridItemRoot = styled.div.withConfig({
     shouldForwardProp: (property, validator) =>
         Utils.blockProperty(property, ['columns', 'rows', 'area']) && validator(property),
-})((props: PApplyGridItem) => applyGridItem(props));
+})(
+    ({ padding, margin, ...rest }: PApplyGridItem) => css`
+        ${applyGridItem(rest)};
+        ${padding && applyPadding(padding)};
+        ${margin && applyMargin(margin)};
+    `
+);
 
 const GridItem = ({ element = DEFAULT_GRID_ITEM_ELEMENT, ...rest }: PGridItem): JSX.Element => (
     <GridItemRoot {...rest} as={element} />

--- a/src/utilities/grid/Grid.tsx
+++ b/src/utilities/grid/Grid.tsx
@@ -26,9 +26,16 @@ const GridRoot = styled.div.withConfig({
     `
 );
 
-const Grid = ({ element = DEFAULT_GRID_ELEMENT, ...rest }: PGrid): JSX.Element => (
-    <GridRoot {...rest} as={element} />
-);
+const Grid = <T extends {}>({
+    element = DEFAULT_GRID_ELEMENT,
+    ...rest
+}: PGrid & T): JSX.Element => {
+    if (Utils.isFunctionalComponent(element)) {
+        return <GridRoot {...rest} forwardedAs={element} />;
+    }
+
+    return <GridRoot {...rest} as={element} />;
+};
 
 const GridItemRoot = styled.div.withConfig({
     shouldForwardProp: (property, validator) =>
@@ -41,9 +48,10 @@ const GridItemRoot = styled.div.withConfig({
     `
 );
 
-const GridItem = ({ element = DEFAULT_GRID_ITEM_ELEMENT, ...rest }: PGridItem): JSX.Element => (
-    <GridItemRoot {...rest} as={element} />
-);
+const GridItem = <T extends {}>({
+    element = DEFAULT_GRID_ITEM_ELEMENT,
+    ...rest
+}: PGridItem & T): JSX.Element => <GridItemRoot {...rest} as={element} />;
 
 export { GridItem };
 

--- a/src/utilities/layout/Flex.props.ts
+++ b/src/utilities/layout/Flex.props.ts
@@ -1,10 +1,8 @@
-import { ReactNode, ReactNodeArray } from 'react';
-
-import { TSpacingDefinition } from '../spacing';
+import { PGlobals } from '../../shared/props';
 
 import { TFlexAlignment, TFlexElement, TFlexFlex, TFlexJustify } from './Flex.types';
 
-type PFlex = {
+type PFlex = PGlobals & {
     /**
      * flex value to use
      * @default 'initial'
@@ -36,14 +34,6 @@ type PFlex = {
      */
     justify?: TFlexJustify;
     /**
-     * padding according to `TSpacingDefinition` typography
-     */
-    padding?: TSpacingDefinition;
-    /**
-     * margin according to `TSpacingDefinition` typography
-     */
-    margin?: TSpacingDefinition;
-    /**
      * restrict the width of a `Grid`
      */
     width?: number;
@@ -51,11 +41,6 @@ type PFlex = {
      * restrict the height of a `Grid`
      */
     height?: number;
-    /**
-     * custom className
-     */
-    className?: string;
-    children?: ReactNode | ReactNodeArray;
 };
 
 export type PFlexRoot = Required<

--- a/src/utilities/layout/Flex.tsx
+++ b/src/utilities/layout/Flex.tsx
@@ -16,7 +16,7 @@ import {
 import PFlex from './Flex.props';
 import FlexRoot from './Flex.root';
 
-const Flex = ({
+const Flex = <T extends {}>({
     element = DEFAULT_FLEX_COMPONENT,
     alignment = DEFAULT_FLEX_ALIGNMENT,
     justify = DEFAULT_FLEX_JUSTIFY,
@@ -24,24 +24,24 @@ const Flex = ({
     row = DEFAULT_FLEX_ROW,
     wrap = DEFAULT_FLEX_WRAP,
     ...rest
-}: PFlex): JSX.Element => {
+}: PFlex & T): JSX.Element => {
     Utils.assert(
         FLEX_ALIGNMENTS.includes(alignment),
-        `Compass Components - Grid: incompatible alignment property (${alignment}) set on Flex component. Please choose from the following: ${FLEX_ALIGNMENTS.join(
+        `Compass Components - Flex: incompatible alignment property (${alignment}) set on Flex component. Please choose from the following: ${FLEX_ALIGNMENTS.join(
             ', '
         )}`
     );
 
     Utils.assert(
         FLEX_JUSTIFIES.includes(justify),
-        `Compass Components - Grid: incompatible justify property (${justify}) set on Flex component. Please choose from the following: ${FLEX_JUSTIFIES.join(
+        `Compass Components - Flex: incompatible justify property (${justify}) set on Flex component. Please choose from the following: ${FLEX_JUSTIFIES.join(
             ', '
         )}`
     );
 
     Utils.assert(
         FLEX_ELEMENTS.includes(element) || Utils.isFunctionalComponent(element),
-        `Compass Components - Grid: incompatible element property (${element}) used in Flex component. Please choose from the following: ${FLEX_ELEMENTS.join(
+        `Compass Components - Flex: incompatible element property (${element}) used in Flex component. Please choose from the following: ${FLEX_ELEMENTS.join(
             ', '
         )}`
     );


### PR DESCRIPTION
#### Summary
introduces new globally shared props types `PGlobalsMisc`, `PGlobalsLayout` and (the previous two combined) `PGlobals` for better/easier props definition with shared props like `className`, `children`, `padding` and `margin`