### PR TITLE
added a fix for the popover zindex

### DIFF
--- a/src/utilities/popover/Popover.tsx
+++ b/src/utilities/popover/Popover.tsx
@@ -43,7 +43,9 @@ const Popover = ({
 
     const style = {
         ...popper,
-        zIndex,
+        // when the Popover is not visible set zIndex to -1 to prevent it from
+        // covering up the action element and make it unclickable
+        zIndex: isVisible ? zIndex : -1,
     };
 
     return (


### PR DESCRIPTION
added zindex of `-1` to the Popover component to prevent it from covering the action element and make it unusable