### PR TITLE
Bugfix/fix grid typing

### DIFF
--- a/src/utilities/grid/Grid.root.tsx
+++ b/src/utilities/grid/Grid.root.tsx
@@ -1,0 +1,38 @@
+import styled, { css } from 'styled-components';
+
+import { Utils } from '../../shared';
+import { applyMargin, applyPadding } from '../spacing';
+
+import { applyGrid, applyGridItem } from './Grid.mixins';
+import { PApplyGrid, PApplyGridItem } from './Grid.props';
+
+const GridRoot = styled.div.withConfig({
+    shouldForwardProp: (property, validator) =>
+        Utils.blockProperty(property, [
+            'columnsTemplate',
+            'rowsTemplate',
+            'areasTemplate',
+            'gap',
+            'placeItems',
+            'placeContent',
+        ]) && validator(property),
+})(
+    ({ padding, margin, ...rest }: PApplyGrid) => css`
+        ${applyGrid(rest)};
+        ${padding && applyPadding(padding)};
+        ${margin && applyMargin(margin)};
+    `
+);
+
+const GridItemRoot = styled.div.withConfig({
+    shouldForwardProp: (property, validator) =>
+        Utils.blockProperty(property, ['columns', 'rows', 'area']) && validator(property),
+})(
+    ({ padding, margin, ...rest }: PApplyGridItem) => css`
+        ${applyGridItem(rest)};
+        ${padding && applyPadding(padding)};
+        ${margin && applyMargin(margin)};
+    `
+);
+
+export { GridRoot, GridItemRoot };

--- a/src/utilities/grid/Grid.tsx
+++ b/src/utilities/grid/Grid.tsx
@@ -1,30 +1,8 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
 
-import { Utils } from '../../shared';
-import { applyMargin, applyPadding } from '../spacing';
-
-import { applyGrid, applyGridItem } from './Grid.mixins';
 import { DEFAULT_GRID_ELEMENT, DEFAULT_GRID_ITEM_ELEMENT } from './Grid.constants';
-import PGrid, { PApplyGrid, PApplyGridItem, PGridItem } from './Grid.props';
-
-const GridRoot = styled.div.withConfig({
-    shouldForwardProp: (property, validator) =>
-        Utils.blockProperty(property, [
-            'columnsTemplate',
-            'rowsTemplate',
-            'areasTemplate',
-            'gap',
-            'placeItems',
-            'placeContent',
-        ]) && validator(property),
-})(
-    ({ padding, margin, ...rest }: PApplyGrid) => css`
-        ${applyGrid(rest)};
-        ${padding && applyPadding(padding)};
-        ${margin && applyMargin(margin)};
-    `
-);
+import PGrid, { PGridItem } from './Grid.props';
+import { GridRoot, GridItemRoot } from './Grid.root';
 
 /**
  * adding a generic Type here allows for safe typing when using elements other
@@ -44,29 +22,39 @@ const GridRoot = styled.div.withConfig({
  * ```
  *
  * In this example neither `width`, `height` nor `radius` are properties of the
- * Grid component, but by using `<PShape>` we safely type those props in, when
+ * `Grid` component, but by using `<PShape>` we safely type those props in, when
  * using the `Shape` component in the `element` prop
  */
-const Grid = <T extends {}>({
-    element = DEFAULT_GRID_ELEMENT,
-    ...rest
-}: PGrid & T): JSX.Element => <GridRoot {...rest} as={element} />;
+const Grid = function <T>({ element = DEFAULT_GRID_ELEMENT, ...rest }: PGrid & T): JSX.Element {
+    return <GridRoot {...rest} as={element} />;
+};
 
-const GridItemRoot = styled.div.withConfig({
-    shouldForwardProp: (property, validator) =>
-        Utils.blockProperty(property, ['columns', 'rows', 'area']) && validator(property),
-})(
-    ({ padding, margin, ...rest }: PApplyGridItem) => css`
-        ${applyGridItem(rest)};
-        ${padding && applyPadding(padding)};
-        ${margin && applyMargin(margin)};
-    `
-);
-
-const GridItem = <T extends {}>({
+/**
+ * adding a generic Type here allows for safe typing when using elements other
+ * than basic HTML (e.g. a `Shape` component)
+ *
+ * @example
+ * ```typescript
+ * <GridItem<PShape>
+ *   element={Shape}
+ *   columns={'1 / 2'}
+ *   padding={Spacing.all(75)}
+ *   width={'100%'}
+ *   radius={8}
+ *   backgroundColor={'#FFF'}
+ * >
+ * ```
+ *
+ * In this example neither `width`, `radius` nor `backgroundColor` are
+ * properties of the `GridItem` component, but by using `<PShape>` we safely
+ * type those props in, when using the `Shape` component in the `element` prop
+ */
+const GridItem = function <T>({
     element = DEFAULT_GRID_ITEM_ELEMENT,
     ...rest
-}: PGridItem & T): JSX.Element => <GridItemRoot {...rest} as={element} />;
+}: PGridItem & T): JSX.Element {
+    return <GridItemRoot {...rest} as={element} />;
+};
 
 export { GridItem };
 

--- a/src/utilities/layout/Flex.tsx
+++ b/src/utilities/layout/Flex.tsx
@@ -16,7 +16,7 @@ import {
 import PFlex from './Flex.props';
 import FlexRoot from './Flex.root';
 
-const Flex = <T extends {}>({
+const Flex = function <T>({
     element = DEFAULT_FLEX_COMPONENT,
     alignment = DEFAULT_FLEX_ALIGNMENT,
     justify = DEFAULT_FLEX_JUSTIFY,
@@ -24,7 +24,7 @@ const Flex = <T extends {}>({
     row = DEFAULT_FLEX_ROW,
     wrap = DEFAULT_FLEX_WRAP,
     ...rest
-}: PFlex & T): JSX.Element => {
+}: PFlex & T): JSX.Element {
     Utils.assert(
         FLEX_ALIGNMENTS.includes(alignment),
         `Compass Components - Flex: incompatible alignment property (${alignment}) set on Flex component. Please choose from the following: ${FLEX_ALIGNMENTS.join(


### PR DESCRIPTION
added a generic type to the `Grid`, `GridItem` and `Flex` to allow for safe typing when using different components in the `element` property