### PR TITLE
Release/0.2.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.2.11",
             "license": "MIT",
             "dependencies": {
-                "@mattermost/compass-icons": "^0.1.6",
+                "@mattermost/compass-icons": "^0.1.10",
                 "@popperjs/core": "^2.9.2",
                 "axios": "^0.21.1",
                 "clsx": "^1.1.1",
@@ -2392,9 +2392,9 @@
             }
         },
         "node_modules/@mattermost/compass-icons": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.6.tgz",
-            "integrity": "sha512-UTDlv244fFtw9PTppN77S1APv+uzv7bOQMwTWEQhmsFZPcIbCtioZPXqOwWJVRjSwZ6GJ/TH0wlamJvgW55HFw==",
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.10.tgz",
+            "integrity": "sha512-h3v9kAKljsEi8VphcEY7lO0a8fk7RWBVF4VK6/ony5sqN+vcqdG/Zn6422Y80ezmd7mtTI1j2Kfbur8+sUUWlQ==",
             "dependencies": {
                 "esm": "^3.2.25",
                 "fontello-batch-cli": "^4.0.0",
@@ -23449,9 +23449,9 @@
             }
         },
         "@mattermost/compass-icons": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.6.tgz",
-            "integrity": "sha512-UTDlv244fFtw9PTppN77S1APv+uzv7bOQMwTWEQhmsFZPcIbCtioZPXqOwWJVRjSwZ6GJ/TH0wlamJvgW55HFw==",
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.10.tgz",
+            "integrity": "sha512-h3v9kAKljsEi8VphcEY7lO0a8fk7RWBVF4VK6/ony5sqN+vcqdG/Zn6422Y80ezmd7mtTI1j2Kfbur8+sUUWlQ==",
             "requires": {
                 "esm": "^3.2.25",
                 "fontello-batch-cli": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mattermost/compass-components",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mattermost/compass-components",
-            "version": "0.2.11",
+            "version": "0.2.12",
             "license": "MIT",
             "dependencies": {
                 "@mattermost/compass-icons": "^0.1.10",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@mattermost/compass-icons": "^0.1.6",
+        "@mattermost/compass-icons": "^0.1.10",
         "@popperjs/core": "^2.9.2",
         "axios": "^0.21.1",
         "clsx": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mattermost/compass-components",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "description": "components aligning to the compass design system",
     "homepage": "https://github.com/mattermost/compass-components#readme",
     "author": "Mattermost",


### PR DESCRIPTION
#### Summary
Releasing a new version for bumping the compass-icon version.
This is needed to fix a bug with an icon that uses a RTL character which breaks alignment 

#### Ticket Link
[MM-38237](https://mattermost.atlassian.net/browse/MM-38237)