### PR TITLE
Support React nodes in the Radio label prop

### DIFF
--- a/src/components/radio/Radio.props.ts
+++ b/src/components/radio/Radio.props.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, ReactNodeArray, MouseEventHandler } from 'react';
+import type { MouseEventHandler } from 'react';
 
 import type { TRadioSizeToken } from './Radio.types';
 
@@ -6,7 +6,7 @@ type PRadio = {
     /**
      * whether the radio button is rendered with a label
      * */
-    label?: string;
+    label?: React.ReactNode | React.ReactNodeArray;
     /**
      * whether the radio button has an error
      * @default false
@@ -39,13 +39,9 @@ type PRadio = {
      * custom classname
      * */
     className?: string;
-    /**
-     * child nodes
-     * */
-    children: ReactNode | ReactNodeArray;
 };
 
-type PRadioRoot = Required<Pick<PRadio, 'hasError' | 'disabled' | 'size' | 'checked' | 'children'>>;
+type PRadioRoot = Required<Pick<PRadio, 'hasError' | 'disabled' | 'size' | 'checked'>>;
 
 type PRadioLabel = Required<Pick<PRadio, 'size'>>;
 

--- a/src/components/radio/Radio.stories.mdx
+++ b/src/components/radio/Radio.stories.mdx
@@ -126,6 +126,16 @@ export const ControlledRadio = (args) => {
     );
 };
 
+export const withChildren = (args) => {
+    const newArgs = { ...defaultArgs };
+    newArgs.label = (
+        <span>
+            main label <span style={{ color: 'gray' }}> - details</span>
+        </span>
+    );
+    return newArgs;
+};
+
 <Canvas hidden>
     <Story
         name="Default"
@@ -139,5 +149,18 @@ export const ControlledRadio = (args) => {
         args={defaultArgs}
     >
         {(args) => <ControlledRadio {...args} />}
+    </Story>
+    <Story
+        name="With ReactNode label"
+        argTypes={{
+            label: { control: { type: 'text' } },
+            size: { control: { type: 'radio', options: RADIO_SIZES } },
+            hasError: { control: { type: 'boolean' } },
+            disabled: { control: { type: 'boolean' } },
+            ...Utils.hideComponentProperties(['onClick', 'className', 'checked', 'children']),
+        }}
+        args={defaultArgs}
+    >
+        {(args) => <ControlledRadio {...withChildren(args)} />}
     </Story>
 </Canvas>

--- a/src/components/radio/Radio.tsx
+++ b/src/components/radio/Radio.tsx
@@ -15,6 +15,7 @@ const Radio: React.FC<PRadio> = (props: PRadio) => {
         disabled = false,
         checked = false,
         onChange = Utils.noop,
+        children,
         ...rest
     } = props;
 
@@ -33,6 +34,7 @@ const Radio: React.FC<PRadio> = (props: PRadio) => {
             <input type={'checkbox'} checked={checked} onChange={onChange} />
             <div />
             {hasLabel && <RadioLabelRoot size={size}>{label}</RadioLabelRoot>}
+            {!hasLabel && children}
         </RadioRoot>
     );
 };

--- a/src/components/radio/Radio.tsx
+++ b/src/components/radio/Radio.tsx
@@ -15,11 +15,13 @@ const Radio: React.FC<PRadio> = (props: PRadio) => {
         disabled = false,
         checked = false,
         onChange = Utils.noop,
-        children,
         ...rest
     } = props;
 
-    const hasLabel = Utils.isString(label) && label.length > 0;
+    const hasLabel =
+        (Utils.isString(label) && label.length > 0) ||
+        Utils.isFunctionalComponent(label) ||
+        (typeof label !== 'boolean' && React.isValidElement(label));
 
     const rootProperties = {
         size,
@@ -34,7 +36,6 @@ const Radio: React.FC<PRadio> = (props: PRadio) => {
             <input type={'checkbox'} checked={checked} onChange={onChange} />
             <div />
             {hasLabel && <RadioLabelRoot size={size}>{label}</RadioLabelRoot>}
-            {!hasLabel && children}
         </RadioRoot>
     );
 };


### PR DESCRIPTION
#### Summary
I would like to use the Radio for a ticket I'm working on. If I use it, I also need support for passing a ReactNode as a label.

Originally, I was thinking of using the children prop as a mutually exclusive alternative to `label`. But then I realized this doesn't play nicely with the sizing, spacing, and color built into `RadioLabel.root.tsx`, so I opted to extend label to also accept `ReactNode`s and added an example story.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38799

